### PR TITLE
corrected name of beautifulsoup package in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ comments data in JSON format for convenient processing.
 
 * `html2text`
 * `markdown`
-* `BeautifulSoup`
+* `beautifulsoup4`
 * `requests`
 
 ## Processing exported data separately


### PR DESCRIPTION

hey, 

thanks again for making this. Newer users may get tripped up that the beautifulsoup package name for python3 is actually beautifulsoup4; not beautifulsoup.  [beatifulsoup pip package is obsolete](https://pypi.org/project/BeautifulSoup/) and installs the old version that is for python 2.x 

I've corrected the readme. 