### PR TITLE
Support converting XML downloaded by some other tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ this has to be done manually for every month of your blog.
 Also [comments are exported separately](http://www.livejournal.com/developer/exporting.bml).
 I wrote this tool to make exporting more convenient.
 
-You will need Python 3 to use it.
+You will need Python 3.4 or newer to use it.
 
 ## export.py
 
@@ -39,6 +39,11 @@ This script will download comments from your blog as
 `comments-json/all.json` with all the comments data in
 JSON format for convenient processing.
 
+## import_ljarchive.py
+
+This script converts the files downloaded by external tool ljarchive (?)
+into the format used by `export.py`.
+
 ## Requirements
 
 * `dateutil`
@@ -54,3 +59,8 @@ In the last lines of `export.py` there's a condition `if True:`.
 Change `True` to `False` to skip the downloading step and go
 directly to the processing of already downloaded data.
 
+## Processing archives created by ljarchive
+
+If you have already downloaded your blog data using ljarchive,
+place them in the `posts-xml` folder and run `import_ljarchive.py`.
+Then follow the steps described in the previous section.

--- a/download_posts.py
+++ b/download_posts.py
@@ -53,12 +53,22 @@ def fetch_month_posts(year, month):
     return response.text
 
 
+max_id = 0
+
+
+def get_max_id():
+    global max_id
+    max_id += 1
+    return max_id
+
+
 def xml_to_json(xml):
     def f(field):
         return xml.findtext(field)
 
+    item_id = f('itemid')
     return {
-        'id': int(f('itemid')),
+        'id': int(item_id) if item_id is not None else get_max_id(),
         'date': f('logtime'),
         'subject': f('subject') or '',
         'body': f('event'),

--- a/download_posts.py
+++ b/download_posts.py
@@ -58,7 +58,7 @@ def xml_to_json(xml):
         return xml.findtext(field)
 
     return {
-        'id': f('itemid'),
+        'id': int(f('itemid')),
         'date': f('logtime'),
         'subject': f('subject') or '',
         'body': f('event'),

--- a/download_posts.py
+++ b/download_posts.py
@@ -69,7 +69,7 @@ def xml_to_json(xml):
     item_id = f('itemid')
     return {
         'id': int(item_id) if item_id is not None else get_max_id(),
-        'date': f('logtime'),
+        'date': f('logtime') or f('eventtime'),
         'subject': f('subject') or '',
         'body': f('event'),
         'eventtime': f('eventtime'),

--- a/download_posts.py
+++ b/download_posts.py
@@ -4,13 +4,11 @@ import os
 import requests
 from sys import exit as sysexit
 import xml.etree.ElementTree as ET
-from datetime import datetime
+from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
-from pathlib import Path
 
 from authentication import authenticated_request_params
 from utilities import save_json_file, save_text_file
-from utilities import xml_post_to_json as xml_to_json
 
 DATE_FORMAT = '%Y-%m'
 
@@ -55,6 +53,23 @@ def fetch_month_posts(year, month):
     return response.text
 
 
+def xml_to_json(xml):
+    def f(field):
+        return xml.findtext(field)
+
+    return {
+        'id': f('itemid'),
+        'date': f('logtime'),
+        'subject': f('subject') or '',
+        'body': f('event'),
+        'eventtime': f('eventtime'),
+        'security': f('security'),
+        'allowmask': f('allowmask'),
+        'current_music': f('current_music'),
+        'current_mood': f('current_mood')
+    }
+
+
 def download_posts():
     os.makedirs('posts-xml', exist_ok=True)
     os.makedirs('posts-json', exist_ok=True)
@@ -79,29 +94,6 @@ def download_posts():
     save_json_file('posts-json/all.json', json_posts)
 
     return json_posts
-
-
-def convert_posts():
-    xml_posts = Path('posts-xml')
-    all_json = Path('posts-json/all.json')
-    if not xml_posts.is_dir():
-        raise NotADirectoryError("Haven't got a posts-xml directory")
-    if not all_json.parent.exists():
-        all_json.parent.mkdir()
-    if not all_json.parent.is_dir():
-        raise NotADirectoryError(f'Not a directory: {all_json.parent}')
-    json_posts = []
-    maxid = 0
-    for xml in xml_posts.iterdir():
-        if xml.suffix == '.xml':
-            for json_post in map(xml_to_json, ET.fromstring(xml.read_text()).iter('entry')):
-                if json_post['id'] is None:
-                    maxid = json_post['id'] = maxid + 1
-                else:
-                    maxid = max((int(json_post['id']), maxid))
-                json_posts.append(json_post)
-
-    save_json_file(str(all_json), json_posts)
 
 
 if __name__ == '__main__':

--- a/download_posts.py
+++ b/download_posts.py
@@ -4,11 +4,13 @@ import os
 import requests
 from sys import exit as sysexit
 import xml.etree.ElementTree as ET
-from datetime import datetime, timedelta
+from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from pathlib import Path
 
 from authentication import authenticated_request_params
 from utilities import save_json_file, save_text_file
+from utilities import xml_post_to_json as xml_to_json
 
 DATE_FORMAT = '%Y-%m'
 
@@ -53,23 +55,6 @@ def fetch_month_posts(year, month):
     return response.text
 
 
-def xml_to_json(xml):
-    def f(field):
-        return xml.findtext(field)
-
-    return {
-        'id': f('itemid'),
-        'date': f('logtime'),
-        'subject': f('subject') or '',
-        'body': f('event'),
-        'eventtime': f('eventtime'),
-        'security': f('security'),
-        'allowmask': f('allowmask'),
-        'current_music': f('current_music'),
-        'current_mood': f('current_mood')
-    }
-
-
 def download_posts():
     os.makedirs('posts-xml', exist_ok=True)
     os.makedirs('posts-json', exist_ok=True)
@@ -94,6 +79,29 @@ def download_posts():
     save_json_file('posts-json/all.json', json_posts)
 
     return json_posts
+
+
+def convert_posts():
+    xml_posts = Path('posts-xml')
+    all_json = Path('posts-json/all.json')
+    if not xml_posts.is_dir():
+        raise NotADirectoryError("Haven't got a posts-xml directory")
+    if not all_json.parent.exists():
+        all_json.parent.mkdir()
+    if not all_json.parent.is_dir():
+        raise NotADirectoryError(f'Not a directory: {all_json.parent}')
+    json_posts = []
+    maxid = 0
+    for xml in xml_posts.iterdir():
+        if xml.suffix == '.xml':
+            for json_post in map(xml_to_json, ET.fromstring(xml.read_text()).iter('entry')):
+                if json_post['id'] is None:
+                    maxid = json_post['id'] = maxid + 1
+                else:
+                    maxid = max((int(json_post['id']), maxid))
+                json_posts.append(json_post)
+
+    save_json_file(str(all_json), json_posts)
 
 
 if __name__ == '__main__':

--- a/export.py
+++ b/export.py
@@ -8,8 +8,9 @@ from bs4 import BeautifulSoup
 from datetime import datetime
 from markdown import markdown
 from operator import itemgetter
+from pathlib import Path
 
-from download_posts import download_posts
+from download_posts import download_posts, convert_posts
 from download_comments import download_comments
 from utilities import save_json_file, save_text_file
 
@@ -62,7 +63,7 @@ def get_slug(json):
     slug = re.compile(r'^-|-$').sub('', slug)
 
     if slug in SLUGS:
-        slug += (len(slug) and '-' or '') + json['id']
+        slug += (len(slug) and '-' or '') + str(json['id'])
 
     SLUGS[slug] = True
 
@@ -185,7 +186,7 @@ def combine(all_posts, all_comments):
         id = json_post['id']
         jitemid = int(id) >> 8
 
-        date = datetime.strptime(json_post['date'], '%Y-%m-%d %H:%M:%S')
+        date = datetime.strptime(json_post.get('date', json_post.get('eventtime')), '%Y-%m-%d %H:%M:%S')
         subfolder = f'{date.year}-{date.month:02d}'
 
         post_comments = jitemid in posts_comments and nest_comments(posts_comments[jitemid]) or None
@@ -211,9 +212,16 @@ if __name__ == '__main__':
     else:
         print('Processing previously downloaded posts and comments…')
 
+        posts_json = Path('posts-json/all.json')
+        if not posts_json.exists():
+            convert_posts()
         with open('posts-json/all.json', 'r', encoding='utf-8') as f:
             all_posts = json.load(f)
-        with open('comments-json/all.json', 'r', encoding='utf-8') as f:
-            all_comments = json.load(f)
+        comments_json = Path('comments-json/all.json')
+        if comments_json.exists():
+            with open('comments-json/all.json', 'r', encoding='utf-8') as f:
+                all_comments = json.load(f)
+        else:
+            all_comments = {}
 
     combine(all_posts, all_comments)

--- a/export.py
+++ b/export.py
@@ -53,7 +53,7 @@ def json_to_html(json):
 def get_slug(json):
     slug = json['subject']
     if not len(slug):
-        slug = json['id']
+        slug = str(json['id'])
 
     if '<' in slug or '&' in slug:
         slug = BeautifulSoup(f'<p>{slug}</p>', features='lxml').text
@@ -62,7 +62,7 @@ def get_slug(json):
     slug = re.compile(r'^-|-$').sub('', slug)
 
     if slug in SLUGS:
-        slug += (len(slug) and '-' or '') + json['id']
+        slug += (len(slug) and '-' or '') + str(json['id'])
 
     SLUGS[slug] = True
 
@@ -183,7 +183,7 @@ def combine(all_posts, all_comments):
 
     for json_post in all_posts:
         id = json_post['id']
-        jitemid = int(id) >> 8
+        jitemid = id >> 8
 
         date = datetime.strptime(json_post['date'], '%Y-%m-%d %H:%M:%S')
         subfolder = f'{date.year}-{date.month:02d}'

--- a/export.py
+++ b/export.py
@@ -8,9 +8,8 @@ from bs4 import BeautifulSoup
 from datetime import datetime
 from markdown import markdown
 from operator import itemgetter
-from pathlib import Path
 
-from download_posts import download_posts, convert_posts
+from download_posts import download_posts
 from download_comments import download_comments
 from utilities import save_json_file, save_text_file
 
@@ -63,7 +62,7 @@ def get_slug(json):
     slug = re.compile(r'^-|-$').sub('', slug)
 
     if slug in SLUGS:
-        slug += (len(slug) and '-' or '') + str(json['id'])
+        slug += (len(slug) and '-' or '') + json['id']
 
     SLUGS[slug] = True
 
@@ -186,7 +185,7 @@ def combine(all_posts, all_comments):
         id = json_post['id']
         jitemid = int(id) >> 8
 
-        date = datetime.strptime(json_post.get('date', json_post.get('eventtime')), '%Y-%m-%d %H:%M:%S')
+        date = datetime.strptime(json_post['date'], '%Y-%m-%d %H:%M:%S')
         subfolder = f'{date.year}-{date.month:02d}'
 
         post_comments = jitemid in posts_comments and nest_comments(posts_comments[jitemid]) or None
@@ -212,16 +211,9 @@ if __name__ == '__main__':
     else:
         print('Processing previously downloaded posts and comments…')
 
-        posts_json = Path('posts-json/all.json')
-        if not posts_json.exists():
-            convert_posts()
         with open('posts-json/all.json', 'r', encoding='utf-8') as f:
             all_posts = json.load(f)
-        comments_json = Path('comments-json/all.json')
-        if comments_json.exists():
-            with open('comments-json/all.json', 'r', encoding='utf-8') as f:
-                all_comments = json.load(f)
-        else:
-            all_comments = {}
+        with open('comments-json/all.json', 'r', encoding='utf-8') as f:
+            all_comments = json.load(f)
 
     combine(all_posts, all_comments)

--- a/import_ljarchive.py
+++ b/import_ljarchive.py
@@ -1,0 +1,31 @@
+import os
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from download_posts import xml_to_json
+from utilities import save_json_file
+
+
+def convert_posts():
+    xml_posts = Path('posts-xml')
+    if not xml_posts.is_dir():
+        raise NotADirectoryError('The xml files have to be in the posts-xml directory, but it doesn’t exist')
+
+    files = [xml for xml in xml_posts.iterdir() if xml.suffix == '.xml']
+    trees = [ET.fromstring(xml.read_text()) for xml in files]
+    entries = [entry for tree in trees for entry in tree.iter('entry')]
+    json_posts = list(map(xml_to_json, entries))
+
+    save_json_file('posts-json/all.json', json_posts)
+
+
+def import_ljarchive():
+    os.makedirs('posts-json', exist_ok=True)
+    os.makedirs('comments-json', exist_ok=True)
+
+    convert_posts()
+    save_json_file('comments-json/all.json', [])
+
+
+if __name__ == '__main__':
+    import_ljarchive()

--- a/utilities.py
+++ b/utilities.py
@@ -1,6 +1,23 @@
 import json
 
 
+def xml_post_to_json(xml):
+    def f(field):
+        return xml.findtext(field)
+
+    return {
+        'id': int(f('itemid') or -1),
+        'date': f('logtime') or f('eventtime'),
+        'subject': f('subject') or '',
+        'body': f('event'),
+        'eventtime': f('eventtime'),
+        'security': f('security'),
+        'allowmask': f('allowmask'),
+        'current_music': f('current_music'),
+        'current_mood': f('current_mood'),
+    }
+
+
 def save_text_file(name, text):
     with open(name, 'w', encoding='utf-8') as file:
         file.write(text)

--- a/utilities.py
+++ b/utilities.py
@@ -1,23 +1,6 @@
 import json
 
 
-def xml_post_to_json(xml):
-    def f(field):
-        return xml.findtext(field)
-
-    return {
-        'id': int(f('itemid') or -1),
-        'date': f('logtime') or f('eventtime'),
-        'subject': f('subject') or '',
-        'body': f('event'),
-        'eventtime': f('eventtime'),
-        'security': f('security'),
-        'allowmask': f('allowmask'),
-        'current_music': f('current_music'),
-        'current_mood': f('current_mood'),
-    }
-
-
 def save_text_file(name, text):
     with open(name, 'w', encoding='utf-8') as file:
         file.write(text)


### PR DESCRIPTION
I had XML files generated by an old Windows program, which I think was called lj-archive. They're in more or less the form that `livejournal-export` expects, though a slightly older XML schema. This PR lets `livejournal-export` convert those to JSON and do its normal thing from there.