### PR TITLE
Retry export failures and decode historical comment XML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ posts-xml
 posts-json
 posts-markdown
 posts-html
+diagnostics/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ this has to be done manually for every month of your blog.
 Also [comments are exported separately](http://www.livejournal.com/developer/exporting.bml).
 I wrote this tool to make exporting more convenient.
 
-You will need Python 3.4 or newer to use it.
+You will need Python 3.12 or newer to use it.
 
 ## export.py
 
@@ -25,6 +25,35 @@ the range of months you want to pull, then will ask for your
 LiveJournal username and password. It will use that to 
 acquire the required session cookies. After this, the
 download process will begin.
+
+## Network errors and historical XML
+
+Login and export share an HTTPS session. Read-only post/comment downloads retry
+transient connection failures, incomplete chunked responses, HTTP 502/503/504,
+and malformed or non-export responses up to four total attempts, waiting 2, 4,
+and 8 seconds. Requests have 15-second connection and 60-second read timeouts.
+Login is not retried, and TLS certificate verification remains enabled.
+
+Unexpected responses are saved privately under `diagnostics/` after the final
+attempt, with safe metadata describing the failure and XML error position.
+These files can contain private post text and are excluded from Git. Request
+headers, cookies, and credentials are not logged. XML-forbidden literal control
+characters are replaced with U+FFFD only if the complete result then passes
+strict parsing; the original response is preserved and the repair is reported.
+Other malformed XML is never silently accepted as an empty month.
+
+Historical comment exports can declare UTF-8 while containing Windows-1251
+subjects/bodies alongside newer UTF-8 comments. Text fields are decoded
+independently: valid UTF-8 is preserved; otherwise the entire field is decoded
+strictly as Windows-1251. This automatic fallback assumes one encoding per field
+and Windows-1251 for legacy text; it does not detect arbitrary legacy encodings.
+Only subject/body payloads are converted. The original bytes are retained and
+the complete result must pass strict XML parsing. No bytes are silently dropped.
+
+## Tests
+
+Install the requirements below, then run `python -m unittest discover -v`.
+Tests use synthetic fixtures and require no LiveJournal credentials or network.
 
 ## download_posts.py
 

--- a/authentication.py
+++ b/authentication.py
@@ -1,7 +1,7 @@
 from getpass import getpass
 from sys import exit as sysexit
 
-import requests
+from http_client import request
 
 
 def get_cookie_value(response, name):
@@ -30,7 +30,7 @@ def get_luid_cookie():
             'sec-ch-ua-platform': '"Windows"',
         }
 
-        response = requests.get('https://www.livejournal.com/', headers=headers)
+        response = request('GET', '/', headers=headers)
 
         return get_cookie_value(response, 'luid')
     except Exception as exception:
@@ -49,18 +49,19 @@ def get_authenticated_cookies():
     }
 
     # login with user credentials and retrieve the two cookies required for the main script functions
-    response = requests.post('https://www.livejournal.com/login.bml', data=credentials, cookies=cookies)
+    response = request('POST', '/login.bml', data=credentials, cookies=cookies)
 
     if not response.ok:
         print(f'Error! Return code: {response.status_code}')
         sysexit(1)
 
     # prepare two cookies necessary for the authenticated requests
-    print('Login successful!')
-    return {
+    authenticated_cookies = {
         'ljloggedin': get_cookie_value(response, 'ljloggedin'),
         'ljmastersession': get_cookie_value(response, 'ljmastersession')
     }
+    print('Login successful!')
+    return authenticated_cookies
 
 
 headers = {

--- a/download_comments.py
+++ b/download_comments.py
@@ -1,21 +1,20 @@
 #!/usr/bin/python3
 
 import os
-import requests
 import xml.etree.ElementTree as ET
 
 from authentication import authenticated_request_params
+from http_client import export_xml
 from utilities import save_json_file, save_text_file
 
 
 def fetch_xml(params):
-    response = requests.get(
-        'https://www.livejournal.com/export_comments.bml',
+    return export_xml(
+        'GET', '/export_comments.bml',
         params=params,
         **authenticated_request_params(),
     )
 
-    return response.text
 
 
 def get_users_map(xml):

--- a/download_posts.py
+++ b/download_posts.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python3
 
 import os
-import requests
 from sys import exit as sysexit
 import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 
 from authentication import authenticated_request_params
+from http_client import export_xml
 from utilities import save_json_file, save_text_file
 
 DATE_FORMAT = '%Y-%m'
@@ -30,8 +30,8 @@ def get_months():
 
 
 def fetch_month_posts(year, month):
-    response = requests.post(
-        'https://www.livejournal.com/export_do.bml',
+    return export_xml(
+        'POST', '/export_do.bml',
         **authenticated_request_params(),
         data={
             'what': 'journal',
@@ -50,7 +50,6 @@ def fetch_month_posts(year, month):
             'field_currents': 'on'
         }
     )
-    return response.text
 
 
 max_id = 0

--- a/export.py
+++ b/export.py
@@ -11,6 +11,7 @@ from operator import itemgetter
 
 from download_posts import download_posts
 from download_comments import download_comments
+from http_client import LiveJournalRequestError
 from utilities import save_json_file, save_text_file
 
 COMMENTS_HEADER = 'Комментарии'
@@ -205,8 +206,11 @@ if __name__ == '__main__':
         print(
             'When complete, you will find post-… and comment-… folders in the current location\ncontaining the differently formated versions of your content.')
 
-        all_posts = download_posts()
-        all_comments = download_comments()
+        try:
+            all_posts = download_posts()
+            all_comments = download_comments()
+        except LiveJournalRequestError as error:
+            raise SystemExit(f'Export stopped: {error}\nDownloaded XML files are kept.') from None
 
     else:
         print('Processing previously downloaded posts and comments…')

--- a/http_client.py
+++ b/http_client.py
@@ -1,0 +1,110 @@
+"""Shared connection pool and bounded retries for read-only export requests."""
+
+import ssl
+import sys
+from time import sleep
+
+import requests
+from xml_responses import ExportResponseError, parse_response, save_response
+
+BASE_URL = 'https://www.livejournal.com'
+MAX_ATTEMPTS = 4
+TIMEOUT = (15, 60)
+EXPORT_REQUESTS = {
+    ('POST', '/export_do.bml'),
+    ('GET', '/export_comments.bml'),
+}
+_session = requests.Session()
+
+
+class LiveJournalRequestError(RuntimeError):
+    pass
+
+
+def _is_tls_eof(error):
+    # requests/urllib3 can wrap the original SSL exception several times.
+    pending = [error]
+    seen = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        if isinstance(current, ssl.SSLEOFError):
+            return True
+        if 'UNEXPECTED_EOF_WHILE_READING' in str(current):
+            return True
+        pending.extend(arg for arg in getattr(current, 'args', ())
+                       if isinstance(arg, BaseException))
+        for name in ('reason', '__cause__', '__context__'):
+            nested = getattr(current, name, None)
+            if isinstance(nested, BaseException):
+                pending.append(nested)
+    return False
+
+
+def request(method, path, *, retry=False, validate=None, **kwargs):
+    """Never replay login. Callers opt in only for read-only export endpoints."""
+    retry = retry and (method.upper(), path) in EXPORT_REQUESTS
+    attempts = MAX_ATTEMPTS if retry else 1
+    kwargs.setdefault('timeout', TIMEOUT)
+    for attempt in range(1, attempts + 1):
+        response = None
+        xml_error = None
+        try:
+            response = _session.request(method, BASE_URL + path, **kwargs)
+            response.raise_for_status()
+            if validate is not None:
+                validate(response)
+            return response
+        except ExportResponseError as error:
+            xml_error = error
+            transient = error.retryable
+            reason = error.reason
+            if error.position is not None:
+                reason += f' at line {error.position[0]}, column {error.position[1]}'
+        except requests.exceptions.SSLError as error:
+            transient = _is_tls_eof(error)
+            reason = 'TLS connection closed unexpectedly' if transient else 'TLS validation or connection failed'
+        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError,
+                requests.exceptions.ChunkedEncodingError):
+            transient = True
+            reason = 'connection interrupted or timed out'
+        except requests.exceptions.HTTPError:
+            transient = response.status_code in (502, 503, 504)
+            reason = f'HTTP {response.status_code}'
+        except requests.exceptions.RequestException:
+            transient = False
+            reason = 'request failed'
+
+        if not transient or attempt == attempts:
+            diagnostic = ''
+            if xml_error is not None:
+                try:
+                    saved = save_response(response, path, kwargs, reason, xml_error.position)
+                    diagnostic = f' Response saved locally: {saved}.'
+                except OSError:
+                    diagnostic = ' Could not save the diagnostic response (check disk access/space).'
+            if response is not None:
+                response.close()
+            # Do not include exceptions, response bodies, cookies, or credentials.
+            raise LiveJournalRequestError(
+                f'{path}: {reason} after {attempt} attempt(s).{diagnostic}'
+            ) from None
+        if response is not None:
+            response.close()
+        delay = 2 ** attempt
+        print(f'{path}: {reason}; retry {attempt + 1}/{attempts} in {delay}s.',
+              file=sys.stderr, flush=True)
+        sleep(delay)
+
+
+def export_xml(method, path, **kwargs):
+    parsed = []
+    def validate(response):
+        parsed.append(parse_response(response, path, kwargs))
+    response = request(method, path, retry=True, validate=validate, **kwargs)
+    try:
+        return parsed[0]
+    finally:
+        response.close()

--- a/test_comment_encoding.py
+++ b/test_comment_encoding.py
@@ -1,0 +1,101 @@
+import contextlib
+import io
+from pathlib import Path
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+import requests
+
+from xml_responses import ExportResponseError, parse_response, save_response
+
+
+def response(raw):
+    result = requests.Response()
+    result.status_code = 200
+    result._content = raw
+    result._content_consumed = True
+    return result
+
+
+def envelope(fields):
+    return b'<?xml version="1.0" encoding="utf-8"?><livejournal><comments>' + fields + b'</comments></livejournal>'
+
+
+class CommentEncodingTests(unittest.TestCase):
+    def setUp(self):
+        folder = self.enterContext(tempfile.TemporaryDirectory())
+        self.enterContext(contextlib.chdir(folder))
+        self.stderr = self.enterContext(contextlib.redirect_stderr(io.StringIO()))
+
+    def test_mixed_encodings_preserve_each_field_and_raw_response(self):
+        old = 'Точно Р°: старый комментарий'
+        modern = 'И новый комментарий 😀'
+        raw = envelope(b'<comment id="1"><subject>' + 'Тема'.encode('cp1251')
+                       + b'</subject><body>' + old.encode('cp1251') + b'</body></comment>'
+                       + b'<comment id="2"><body>' + modern.encode('utf-8')
+                       + b'</body></comment><comment id="3" state="D"/>')
+        xml = parse_response(response(raw), '/export_comments.bml', {})
+        root = ET.fromstring(xml)
+        self.assertEqual([x.text for x in root.iter('body')], [old, modern])
+        self.assertEqual(root.find('.//subject').text, 'Тема')
+        self.assertEqual(len(list(root.iter('comment'))), 3)
+        self.assertNotIn('\ufffd', xml)
+        saved = next(Path('diagnostics').glob('*.response.bin'))
+        self.assertEqual(saved.read_bytes(), raw)
+        self.assertEqual(saved.stat().st_mode & 0o777, 0o600)
+        self.assertNotIn(old, self.stderr.getvalue())
+
+    def test_subject_and_body_can_use_different_encodings(self):
+        raw = envelope(b'<comment id="1"><subject>' + 'Старая'.encode('cp1251')
+                       + b'</subject><body>' + 'Новая И'.encode('utf-8') + b'</body></comment>')
+        root = ET.fromstring(parse_response(response(raw), '/export_comments.bml', {}))
+        self.assertEqual(root.find('.//subject').text, 'Старая')
+        self.assertEqual(root.find('.//body').text, 'Новая И')
+
+    def test_cdata_and_numeric_entities_keep_meaning(self):
+        raw = envelope(b'<comment id="1"><subject>' + 'Тема'.encode('cp1251')
+                       + b' &#1048;</subject><body><![CDATA[' + 'Текст <tag>'.encode('cp1251')
+                       + b']]></body></comment>')
+        root = ET.fromstring(parse_response(response(raw), '/export_comments.bml', {}))
+        self.assertEqual(root.find('.//subject').text, 'Тема И')
+        self.assertEqual(root.find('.//body').text, 'Текст <tag>')
+
+    def test_bad_bytes_outside_known_fields_are_not_guessed(self):
+        raw = envelope(b'<comment id="1" posterid="\xff"><body>'
+                       + 'Текст'.encode('cp1251') + b'</body></comment>')
+        with self.assertRaises(ExportResponseError):
+            parse_response(response(raw), '/export_comments.bml', {})
+
+    def test_legacy_field_with_control_character_preserves_both_repairs(self):
+        raw = envelope(b'<comment id="1"><body>' + 'Привет'.encode('cp1251')
+                       + b'\x01' + ' мир'.encode('cp1251') + b'</body></comment>')
+        parsed = parse_response(response(raw), '/export_comments.bml', {})
+        self.assertEqual(ET.fromstring(parsed).find('.//body').text, 'Привет\ufffd мир')
+        self.assertEqual(next(Path('diagnostics').glob('*.response.bin')).read_bytes(), raw)
+        self.assertIn('Windows-1251', self.stderr.getvalue())
+        self.assertIn('U+FFFD', self.stderr.getvalue())
+
+    def test_undefined_legacy_byte_is_not_replaced(self):
+        raw = envelope(b'<comment id="1"><body>\xff\x98</body></comment>')
+        with self.assertRaises(ExportResponseError):
+            parse_response(response(raw), '/export_comments.bml', {})
+
+    def test_existing_failed_response_can_be_repaired_without_rewriting_original(self):
+        raw = envelope(b'<comment id="1"><body>' + 'Текст'.encode('cp1251') + b'</body></comment>')
+        r = response(raw)
+        saved = save_response(r, '/export_comments.bml', {}, 'original encoding failure')
+        before = saved.stat().st_mtime_ns
+        parsed = parse_response(r, '/export_comments.bml', {})
+        self.assertEqual(ET.fromstring(parsed).find('.//body').text, 'Текст')
+        self.assertEqual(saved.read_bytes(), raw)
+        self.assertEqual(saved.stat().st_mtime_ns, before)
+
+    def test_legacy_fallback_is_not_used_for_post_exports(self):
+        raw = b'<livejournal><entry><event>' + 'Текст'.encode('cp1251') + b'</event></entry></livejournal>'
+        with self.assertRaises(ExportResponseError):
+            parse_response(response(raw), '/export_do.bml', {})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_export_responses.py
+++ b/test_export_responses.py
@@ -1,0 +1,91 @@
+import contextlib
+import io
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import requests
+
+import download_posts
+import download_comments
+import http_client
+
+
+def response(body):
+    result = requests.Response()
+    result.status_code = 200
+    result._content = body.encode('utf-8')
+    result.encoding = 'utf-8'
+    result._content_consumed = True
+    return result
+
+
+class ExportResponseTests(unittest.TestCase):
+    def setUp(self):
+        folder = self.enterContext(tempfile.TemporaryDirectory())
+        self.enterContext(contextlib.chdir(folder))
+        self.enterContext(patch.object(http_client, 'sleep'))
+        self.enterContext(contextlib.redirect_stderr(io.StringIO()))
+
+    def test_valid_empty_month_is_accepted(self):
+        xml = '<livejournal/>'
+        with patch.object(http_client._session, 'request', return_value=response(xml)):
+            self.assertEqual(http_client.export_xml('POST', '/export_do.bml'), xml)
+
+    def test_html_and_malformed_responses_are_rejected_without_body(self):
+        for body in ('<html><body>private-token</body></html>',
+                     '<html>private-token', 'private-token'):
+            with self.subTest(body=body):
+                with patch.object(http_client._session, 'request', return_value=response(body)):
+                    with self.assertRaises(http_client.LiveJournalRequestError) as caught:
+                        http_client.export_xml('POST', '/export_do.bml')
+                self.assertNotIn('private-token', str(caught.exception))
+
+    def test_download_recovers_from_eof_and_saves_post(self):
+        xml = ('<livejournal><entry><itemid>256</itemid>'
+               '<eventtime>2024-01-02 03:04:05</eventtime>'
+               '<subject>Test</subject><event>Post body</event>'
+               '</entry></livejournal>')
+        with tempfile.TemporaryDirectory() as folder, contextlib.chdir(folder), \
+                patch('builtins.input', side_effect=['2024-01', '2024-01']), \
+                patch.object(download_posts, 'authenticated_request_params', return_value={}), \
+                patch.object(http_client._session, 'request', side_effect=[
+                    requests.exceptions.SSLError('UNEXPECTED_EOF_WHILE_READING'), response(xml)
+                ]) as send, patch.object(http_client, 'sleep'), \
+                contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            posts = download_posts.download_posts()
+            self.assertEqual(posts[0]['body'], 'Post body')
+            self.assertEqual(Path('posts-xml/2024-01.xml').read_text(), xml)
+            self.assertTrue(Path('posts-json/all.json').is_file())
+            self.assertEqual(send.call_count, 2)
+
+    def test_invalid_response_does_not_overwrite_existing_month(self):
+        with tempfile.TemporaryDirectory() as folder, contextlib.chdir(folder), \
+                patch('builtins.input', side_effect=['2024-01', '2024-01']), \
+                patch.object(download_posts, 'authenticated_request_params', return_value={}), \
+                patch.object(http_client._session, 'request', return_value=response('<html/>')), \
+                contextlib.redirect_stdout(io.StringIO()):
+            os.mkdir('posts-xml')
+            existing = Path('posts-xml/2024-01.xml')
+            existing.write_text('previous backup')
+            with self.assertRaises(http_client.LiveJournalRequestError):
+                download_posts.download_posts()
+            self.assertEqual(existing.read_text(), 'previous backup')
+
+    def test_comment_download_uses_same_retry_client(self):
+        xml = '<livejournal><comments/></livejournal>'
+        with patch.object(download_comments, 'authenticated_request_params', return_value={}), \
+                patch.object(http_client._session, 'request', side_effect=[
+                    requests.exceptions.Timeout(), response(xml)
+                ]) as send, patch.object(http_client, 'sleep'), \
+                contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(download_comments.fetch_xml({'get': 'comment_body', 'startid': 1}), xml)
+            self.assertEqual(send.call_count, 2)
+            self.assertEqual(send.call_args.args[:2],
+                             ('GET', 'https://www.livejournal.com/export_comments.bml'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_http_client.py
+++ b/test_http_client.py
@@ -1,0 +1,190 @@
+"""Offline regression checks for the export HTTP transport."""
+
+import contextlib
+import io
+import ssl
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+from urllib3.exceptions import MaxRetryError, SSLError as Urllib3SSLError
+
+import http_client
+
+
+class HttpClientTests(unittest.TestCase):
+    SECRET = 'ljmastersession=do-not-print-this-cookie'
+
+    def setUp(self):
+        self.send = self.enterContext(patch.object(http_client._session, 'request'))
+        self.sleep = self.enterContext(patch.object(http_client, 'sleep'))
+        self.output = io.StringIO()
+        self.enterContext(contextlib.redirect_stdout(self.output))
+        self.enterContext(contextlib.redirect_stderr(self.output))
+
+    def response(self, status=200):
+        response = requests.Response()
+        response.status_code = status
+        response.url = 'https://www.livejournal.com/export_do.bml'
+        response._content = (
+            b'<livejournal />' if status == 200 else self.SECRET.encode()
+        )
+        response.close = Mock()
+        return response
+
+    def eof(self):
+        return requests.exceptions.SSLError(
+            MaxRetryError(
+                None,
+                '/export_do.bml',
+                reason=Urllib3SSLError(
+                    ssl.SSLEOFError(8, 'TLS connection closed ' + self.SECRET)
+                ),
+            )
+        )
+
+    def assert_safe_failure(self, method='POST', path='/export_do.bml', retry=True):
+        with self.assertRaises(http_client.LiveJournalRequestError) as caught:
+            http_client.request(method, path, retry=retry)
+        self.assertNotIn(self.SECRET, str(caught.exception))
+        self.assertNotIn(self.SECRET, self.output.getvalue())
+
+    def test_nested_ssl_eof_retries_then_returns_response(self):
+        response = self.response()
+        self.send.side_effect = [self.eof(), response]
+
+        result = http_client.request('POST', '/export_do.bml', retry=True)
+
+        self.assertIs(result, response)
+        self.assertEqual(self.send.call_count, 2)
+        self.sleep.assert_called_once()
+        self.assertNotIn(self.SECRET, self.output.getvalue())
+
+    def test_ssl_eof_text_is_also_retryable(self):
+        response = self.response()
+        self.send.side_effect = [
+            requests.exceptions.SSLError('UNEXPECTED_EOF_WHILE_READING'),
+            response,
+        ]
+
+        self.assertIs(
+            http_client.request('GET', '/export_comments.bml', retry=True),
+            response,
+        )
+        self.assertEqual(self.send.call_count, 2)
+
+    def test_ssl_eof_exhausts_after_four_attempts(self):
+        self.send.side_effect = self.eof()
+
+        self.assert_safe_failure()
+
+        self.assertEqual(self.send.call_count, 4)
+        self.assertEqual(self.sleep.call_count, 3)
+
+    def test_login_is_not_replayed(self):
+        self.send.side_effect = self.eof()
+
+        self.assert_safe_failure(path='/login.bml', retry=False)
+
+        self.send.assert_called_once()
+        self.sleep.assert_not_called()
+
+    def test_certificate_verification_failure_is_not_retried(self):
+        self.send.side_effect = requests.exceptions.SSLError(
+            ssl.SSLCertVerificationError(
+                1, 'CERTIFICATE_VERIFY_FAILED ' + self.SECRET
+            )
+        )
+
+        self.assert_safe_failure()
+
+        self.send.assert_called_once()
+        self.sleep.assert_not_called()
+
+    def test_other_ssl_failure_is_not_retried(self):
+        self.send.side_effect = requests.exceptions.SSLError(
+            'WRONG_VERSION_NUMBER ' + self.SECRET
+        )
+
+        self.assert_safe_failure()
+
+        self.send.assert_called_once()
+        self.sleep.assert_not_called()
+
+    def test_forbidden_is_not_retried_or_leaked(self):
+        self.send.return_value = self.response(403)
+
+        self.assert_safe_failure()
+
+        self.send.assert_called_once()
+        self.sleep.assert_not_called()
+
+    def test_retryable_http_response_is_closed_before_retry(self):
+        for status in (502, 503, 504):
+            with self.subTest(status=status):
+                failed = self.response(status)
+                successful = self.response()
+                self.send.reset_mock()
+                self.sleep.reset_mock()
+                self.send.side_effect = [failed, successful]
+
+                self.assertIs(
+                    http_client.request('POST', '/export_do.bml', retry=True),
+                    successful,
+                )
+
+                self.assertEqual(self.send.call_count, 2)
+                failed.close.assert_called_once()
+                successful.close.assert_not_called()
+                self.sleep.assert_called_once()
+
+    def test_retryable_http_exhaustion_is_bounded_and_sanitized(self):
+        self.send.side_effect = [self.response(503) for _ in range(4)]
+
+        self.assert_safe_failure()
+
+        self.assertEqual(self.send.call_count, 4)
+        self.assertEqual(self.sleep.call_count, 3)
+
+    def test_timeout_and_connection_error_retry_for_export(self):
+        for error_type in (
+            requests.exceptions.Timeout,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ChunkedEncodingError,
+        ):
+            with self.subTest(error_type=error_type.__name__):
+                successful = self.response()
+                self.send.reset_mock()
+                self.sleep.reset_mock()
+                self.send.side_effect = [error_type(self.SECRET), successful]
+
+                self.assertIs(
+                    http_client.request('GET', '/export_comments.bml', retry=True),
+                    successful,
+                )
+
+                self.assertEqual(self.send.call_count, 2)
+                self.assertNotIn(self.SECRET, self.output.getvalue())
+
+    def test_incomplete_login_response_is_not_replayed(self):
+        self.send.side_effect = requests.exceptions.ChunkedEncodingError(self.SECRET)
+        self.assert_safe_failure(path='/login.bml', retry=False)
+        self.send.assert_called_once()
+        self.sleep.assert_not_called()
+
+    def test_requests_have_timeout_and_keep_certificate_validation(self):
+        self.send.return_value = self.response()
+
+        http_client.request('POST', '/export_do.bml', retry=True, data={'year': 2024})
+
+        self.send.assert_called_once()
+        kwargs = self.send.call_args.kwargs
+        self.assertEqual(kwargs['timeout'], (15, 60))
+        self.assertIs(http_client._session.verify, True)
+        self.assertIs(kwargs.get('verify', True), True)
+        self.assertEqual(kwargs['data'], {'year': 2024})
+        self.assertNotIn('retry', kwargs)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_xml_responses.py
+++ b/test_xml_responses.py
@@ -1,0 +1,195 @@
+"""Offline regressions for malformed export responses and private diagnostics."""
+
+import contextlib
+import hashlib
+import io
+import json
+from pathlib import Path
+import stat
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+import xml.etree.ElementTree as ET
+
+import requests
+
+import http_client
+import xml_responses
+
+
+class XmlResponseTests(unittest.TestCase):
+    USERNAME = 'private-example-username'
+    COOKIE = 'private-example-session-cookie'
+    TOKEN = 'private-example-query-token'
+    BODY = 'private-example-post-body'
+    VALID = b'<livejournal><entry><itemid>1</itemid><event>ok</event></entry></livejournal>'
+
+    def setUp(self):
+        folder = self.enterContext(tempfile.TemporaryDirectory())
+        self.enterContext(contextlib.chdir(folder))
+        self.output = io.StringIO()
+        self.enterContext(contextlib.redirect_stdout(self.output))
+        self.enterContext(contextlib.redirect_stderr(self.output))
+        self.send = self.enterContext(patch.object(http_client._session, 'request'))
+        self.sleep = self.enterContext(patch.object(http_client, 'sleep'))
+
+    def response(self, raw, *, encoding='utf-8'):
+        response = requests.Response()
+        response.status_code = 200
+        response._content = raw
+        response._content_consumed = True
+        response.encoding = encoding
+        response.url = f'https://www.livejournal.com/export_do.bml?token={self.TOKEN}'
+        response.headers['Set-Cookie'] = f'ljmastersession={self.COOKIE}'
+        response.close = Mock()
+        return response
+
+    def export(self):
+        return http_client.export_xml(
+            'POST', '/export_do.bml',
+            data={'year': 2009, 'month': '04', 'user': self.USERNAME},
+            cookies={'ljmastersession': self.COOKIE},
+            headers={'Authorization': self.TOKEN},
+        )
+
+    def assert_no_secrets(self, text):
+        for secret in (self.USERNAME, self.COOKIE, self.TOKEN, self.BODY):
+            self.assertNotIn(secret, text)
+
+    def diagnostic_path(self, raw):
+        digest = hashlib.sha256(raw).hexdigest()[:16]
+        return Path(f'diagnostics/export_do-2009-04-{digest}.response.bin')
+
+    def assert_private_diagnostic(self, raw):
+        path = self.diagnostic_path(raw)
+        self.assertEqual(path.read_bytes(), raw)
+        self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+        metadata_path = path.with_suffix('.json')
+        self.assertEqual(stat.S_IMODE(metadata_path.stat().st_mode), 0o600)
+        metadata_text = metadata_path.read_text()
+        self.assert_no_secrets(metadata_text)
+        metadata = json.loads(metadata_text)
+        self.assertEqual(metadata['bytes'], len(raw))
+        self.assertEqual(metadata['sha256'], hashlib.sha256(raw).hexdigest())
+        self.assertEqual(metadata['endpoint'], '/export_do.bml')
+        self.assertEqual(metadata['status'], 200)
+        self.assertEqual(stat.S_IMODE(Path('diagnostics').stat().st_mode), 0o700)
+
+    def assert_bounded_failure(self, raw):
+        responses = [self.response(raw) for _ in range(http_client.MAX_ATTEMPTS)]
+        self.send.side_effect = responses
+        with self.assertRaises(http_client.LiveJournalRequestError) as caught:
+            self.export()
+        self.assertEqual(self.send.call_count, http_client.MAX_ATTEMPTS)
+        self.assertEqual(self.sleep.call_count, http_client.MAX_ATTEMPTS - 1)
+        self.assert_no_secrets(str(caught.exception))
+        self.assert_no_secrets(self.output.getvalue())
+        for response in responses:
+            response.close.assert_called_once()
+        self.assert_private_diagnostic(raw)
+        return caught.exception
+
+    def test_html_then_xml_retries_and_succeeds_without_diagnostics(self):
+        invalid = self.response(f'<html><body>{self.BODY}</body></html>'.encode())
+        valid = self.response(self.VALID)
+        self.send.side_effect = [invalid, valid]
+
+        result = self.export()
+
+        self.assertEqual(result, self.VALID.decode())
+        self.assertEqual(self.send.call_count, 2)
+        self.sleep.assert_called_once_with(2)
+        invalid.close.assert_called_once()
+        valid.close.assert_called_once()
+        self.assertFalse(Path('diagnostics').exists())
+        self.assert_no_secrets(self.output.getvalue())
+
+    def test_repeated_malformed_xml_saves_exact_private_response(self):
+        raw = f'<livejournal><entry><event>{self.BODY}</event>'.encode()
+        self.assert_bounded_failure(raw)
+
+    def test_control_character_repair_preserves_full_content_and_original_bytes(self):
+        raw = (
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<livejournal><entry><itemid>1</itemid>'
+            f'<event>Начало\x01{self.BODY} конец</event></entry>'
+            '<entry><itemid>2</itemid><event>Вторая запись</event></entry></livejournal>'
+        ).encode('utf-8')
+        response = self.response(raw)
+        self.send.return_value = response
+
+        result = self.export()
+
+        self.assertEqual(result, raw.decode('utf-8').replace('\x01', '\ufffd'))
+        root = ET.fromstring(result)
+        self.assertEqual(len(root.findall('entry')), 2)
+        self.assertEqual(root[0].findtext('event'), f'Начало\ufffd{self.BODY} конец')
+        self.assertEqual(root[1].findtext('event'), 'Вторая запись')
+        self.send.assert_called_once()
+        self.sleep.assert_not_called()
+        response.close.assert_called_once()
+        self.assert_private_diagnostic(raw)
+        self.assert_no_secrets(self.output.getvalue())
+        self.assertIn('U+FFFD', self.output.getvalue())
+
+    def test_xml_declaration_overrides_wrong_http_charset(self):
+        text = ('<?xml version="1.0" encoding="windows-1251"?>'
+                '<livejournal><entry><event>Привет, мир!</event></entry></livejournal>')
+        self.send.return_value = self.response(text.encode('cp1251'), encoding='utf-8')
+
+        result = self.export()
+
+        self.assertEqual(ET.fromstring(result)[0].findtext('event'), 'Привет, мир!')
+        self.assertIn('encoding="utf-8"', result)
+        self.assertNotIn('\ufffd', result)
+        self.assertFalse(Path('diagnostics').exists())
+
+    def test_utf8_body_ignores_incorrect_latin1_http_encoding(self):
+        raw = ('<?xml version="1.0" encoding="utf-8"?>'
+               '<livejournal><entry><event>Привет</event></entry></livejournal>').encode()
+        self.send.return_value = self.response(raw, encoding='ISO-8859-1')
+
+        result = self.export()
+
+        self.assertEqual(result, raw.decode('utf-8'))
+        self.assertNotIn('\ufffd', result)
+
+    def test_empty_body_retries_then_saves_zero_byte_diagnostic(self):
+        error = self.assert_bounded_failure(b'')
+        self.assertIn('empty response', str(error))
+
+    def test_bare_html_is_retried_and_archived_without_printing_body(self):
+        raw = f'<!doctype html><html><body>{self.USERNAME} {self.BODY}'.encode()
+        error = self.assert_bounded_failure(raw)
+        self.assertIn('HTML', str(error))
+
+    def test_truncated_xml_is_never_accepted_even_if_it_contains_control_characters(self):
+        raw = (f'<livejournal><entry><event>\x01{self.BODY}</event></entry>'
+               '<entry><event>second').encode()
+        self.assert_bounded_failure(raw)
+
+    def test_bare_error_text_in_livejournal_root_is_not_an_empty_month(self):
+        self.assert_bounded_failure(f'<livejournal>{self.BODY}</livejournal>'.encode())
+
+    def test_nonascii_encoding_declaration_has_bounded_sanitized_failure(self):
+        raw = b'<?xml version="1.0" encoding="\xff"?><livejournal/>'
+        self.assert_bounded_failure(raw)
+
+    def test_incomplete_existing_diagnostic_stops_repair_without_false_success(self):
+        raw = b'<livejournal><entry><event>before\x01after</event></entry></livejournal>'
+        path = self.diagnostic_path(raw)
+        path.parent.mkdir(mode=0o700)
+        path.write_bytes(b'incomplete diagnostic')
+        self.send.return_value = self.response(raw)
+
+        with self.assertRaises(http_client.LiveJournalRequestError) as caught:
+            self.export()
+
+        self.assertEqual(path.read_bytes(), b'incomplete diagnostic')
+        self.assertIn('cannot preserve the original', str(caught.exception))
+        self.assertNotIn('original response kept', self.output.getvalue())
+        self.assert_no_secrets(self.output.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/xml_responses.py
+++ b/xml_responses.py
@@ -1,0 +1,209 @@
+"""Strict export parsing, with private copies of unexpected server responses."""
+
+import codecs
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from xml.parsers import expat
+
+
+class ExportResponseError(Exception):
+    def __init__(self, reason, *, retryable=True, position=None):
+        self.reason = reason
+        self.retryable = retryable
+        self.position = position
+
+
+def save_response(response, endpoint, options, reason, position=None):
+    """Save body locally, never cookies/request headers or credentials."""
+    raw = response.content
+    digest = hashlib.sha256(raw).hexdigest()
+    label = endpoint.strip('/').replace('.bml', '')
+    data = options.get('data', {})
+    if str(data.get('year', '')).isdigit() and str(data.get('month', '')).isdigit():
+        label += f'-{int(data["year"]):04d}-{int(data["month"]):02d}'
+    folder = Path('diagnostics')
+    folder.mkdir(mode=0o700, exist_ok=True)
+    path = folder / f'{label}-{digest[:16]}.response.bin'
+    metadata = {'endpoint': endpoint, 'status': response.status_code,
+                'bytes': len(raw), 'sha256': digest, 'reason': reason,
+                'xml_error_position': position}
+    for target, body in ((path, raw), (path.with_suffix('.json'),
+                         json.dumps(metadata, indent=2).encode('utf-8'))):
+        fd, temporary = tempfile.mkstemp(prefix='.response-', dir=folder)
+        try:
+            with os.fdopen(fd, 'wb') as file:
+                file.write(body)
+                file.flush()
+                os.fsync(file.fileno())
+            try:
+                os.link(temporary, target)
+            except FileExistsError:
+                existing = target.read_bytes()
+                if existing != body:
+                    # The same response may first fail and later be repaired.
+                    # Keep the original diagnostic note if its identity matches.
+                    if target == path:
+                        raise OSError('Existing diagnostic copy differs from the response.')
+                    try:
+                        previous = json.loads(existing)
+                        matches = (previous['sha256'] == digest
+                                   and previous['bytes'] == len(raw)
+                                   and previous['endpoint'] == endpoint)
+                    except (ValueError, KeyError, TypeError):
+                        matches = False
+                    if not matches:
+                        raise OSError('Existing diagnostic metadata is incomplete or inconsistent.')
+        finally:
+            os.unlink(temporary)
+    return path
+
+
+def _decode(raw):
+    # The XML declaration/BOM takes precedence over the HTTP charset.
+    if raw.startswith((codecs.BOM_UTF32_LE, codecs.BOM_UTF32_BE)):
+        encoding = 'utf-32'
+    elif raw.startswith((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE)):
+        encoding = 'utf-16'
+    elif raw.startswith(b'\x00<\x00?'):
+        encoding = 'utf-16-be'
+    elif raw.startswith(b'<\x00?\x00'):
+        encoding = 'utf-16-le'
+    else:
+        declaration = re.match(br'\s*<\?xml\b[^?]*\bencoding\s*=\s*[\'"]([^\'"]+)', raw[:256])
+        try:
+            encoding = declaration.group(1).decode('ascii') if declaration else 'utf-8-sig'
+        except UnicodeError:
+            raise ExportResponseError('response has an invalid XML encoding declaration') from None
+    try:
+        text = raw.decode(encoding)
+    except (UnicodeError, LookupError):
+        raise ExportResponseError('response has invalid or unsupported XML encoding') from None
+    # Callers save strings as UTF-8, so keep the declaration consistent.
+    return re.sub(r'(<\?xml\b[^?]*\bencoding\s*=\s*)([\'"])[^\'"]+\2',
+                  r'\1"utf-8"', text, count=1)
+
+
+def _transcode_comment_fields(raw):
+    """Repair legacy CP1251 fields without re-decoding modern UTF-8 fields.
+
+    The single-byte parser is used only to locate XML field byte boundaries;
+    its decoded text is never used as archive content.
+    """
+    parser = expat.ParserCreate('iso-8859-1')
+    stack = []
+    ranges = []
+    starts = {}
+    parent = ['livejournal', 'comments', 'comment']
+
+    def start(name, attrs):
+        if stack[:3] == parent and len(stack) > 3:
+            raise ExportResponseError('nested markup in a legacy comment text field', retryable=False)
+        if stack == parent and name in ('body', 'subject'):
+            offset = parser.CurrentByteIndex
+            opening_end = raw.find(b'>', offset) + 1
+            opening = raw[offset:opening_end]
+            if attrs:
+                raise ExportResponseError('unexpected attributes in a legacy comment text field', retryable=False)
+            if not opening.rstrip().endswith(b'/>'):
+                starts[name] = opening_end
+        stack.append(name)
+
+    def end(name):
+        if stack == parent + [name] and name in starts:
+            ranges.append((starts.pop(name), parser.CurrentByteIndex))
+        stack.pop()
+
+    def reject_doctype(*args):
+        raise ExportResponseError('DTD is unsupported in a legacy comment export', retryable=False)
+
+    parser.StartElementHandler = start
+    parser.EndElementHandler = end
+    parser.StartDoctypeDeclHandler = reject_doctype
+    parser.ExternalEntityRefHandler = lambda *args: 0
+    try:
+        # Locate fields even when legacy text also contains XML-forbidden C0
+        # bytes. This shadow copy has identical byte offsets; original payloads
+        # are transcoded below and the strict parser handles control repair.
+        shadow = re.sub(br'[\x00-\x08\x0b\x0c\x0e-\x1f]', b' ', raw)
+        parser.Parse(shadow, True)
+        chunks = []
+        cursor = 0
+        converted = 0
+        for first, last in ranges:
+            payload = raw[first:last]
+            try:
+                payload.decode('utf-8')
+            except UnicodeDecodeError:
+                payload = payload.decode('cp1251').encode('utf-8')
+                converted += 1
+            chunks.extend((raw[cursor:first], payload))
+            cursor = last
+        chunks.append(raw[cursor:])
+        result = b''.join(chunks)
+        result.decode('utf-8')  # No guessing for bytes outside known text fields.
+    except (UnicodeError, expat.ExpatError):
+        raise ExportResponseError(
+            'comment XML cannot be decoded as UTF-8 with legacy Windows-1251 text fields',
+            retryable=False,
+        ) from None
+    return result, converted
+
+
+def parse_response(response, endpoint, options):
+    raw = response.content
+    if not raw.strip():
+        raise ExportResponseError('empty response body')
+    if re.match(br'\s*(?:<!doctype\s+html\b|<html\b)', raw, re.I):
+        raise ExportResponseError('server returned an HTML page instead of an XML export')
+    legacy_fields = 0
+    try:
+        text = _decode(raw)
+    except ExportResponseError:
+        if endpoint != '/export_comments.bml':
+            raise
+        normalized, legacy_fields = _transcode_comment_fields(raw)
+        text = _decode(normalized)
+    repaired = 0
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError as error:
+        # Only XML-forbidden literal characters are repairable here. Never use
+        # a permissive parser that could silently discard entries or content.
+        cleaned, repaired = re.subn(r'[\x00-\x08\x0b\x0c\x0e-\x1f\ufffe\uffff]', '\ufffd', text)
+        if repaired:
+            try:
+                root = ET.fromstring(cleaned)
+                text = cleaned
+            except ET.ParseError:
+                raise ExportResponseError('malformed XML', position=error.position) from None
+        else:
+            raise ExportResponseError('malformed XML', position=error.position) from None
+    if root.tag != 'livejournal':
+        raise ExportResponseError('response is not a LiveJournal XML export')
+    if (root.text and root.text.strip()) or any(child.tail and child.tail.strip() for child in root):
+        raise ExportResponseError('export contains unexpected text outside its records')
+    if endpoint == '/export_do.bml' and any(child.tag != 'entry' for child in root):
+        raise ExportResponseError('post export contains an unexpected error or element')
+    if root.find('error') is not None:
+        raise ExportResponseError('LiveJournal returned an XML error', retryable=False)
+    if repaired or legacy_fields:
+        changes = []
+        if repaired:
+            changes.append(f'replaced {repaired} XML-forbidden literal characters with U+FFFD')
+        if legacy_fields:
+            changes.append(f'transcoded {legacy_fields} Windows-1251 comment fields to UTF-8')
+        reason = '; '.join(changes)
+        try:
+            saved = save_response(response, endpoint, options, reason)
+        except OSError:
+            raise ExportResponseError('cannot preserve the original response before repairing XML',
+                                      retryable=False) from None
+        print(f'{endpoint}: {reason}; original response kept in {saved}.',
+              file=sys.stderr, flush=True)
+    return text


### PR DESCRIPTION
An export can stop midway when LiveJournal closes an HTTPS connection, returns an HTML/error response, or labels historical Windows-1251 comment text as UTF-8. This change retries transient export failures and validates the downloaded XML before passing it to the existing converters.

Login and downloads share a Requests session with explicit connect/read timeouts. Read-only export requests retry connection failures, truncated chunked responses, HTTP 502/503/504, and invalid export responses, with four total attempts and 2/4/8-second backoff. Login and certificate verification failures are not retried; TLS verification stays enabled.

Historical comment subjects and bodies are handled individually: valid UTF-8 fields are preserved, while fields that fail strict UTF-8 decoding are automatically decoded as Windows-1251. This assumes one encoding per field and Windows-1251 for legacy text; it is not a general charset detector and requires no configuration option. Only those text payloads are converted, and the complete result must pass strict XML parsing. Literal XML-forbidden control characters can be replaced with U+FFFD when that yields valid XML.

Original responses are retained for repairs and final validation failures in private, Git-ignored diagnostic files, alongside limited metadata. Credentials, cookies, and request headers are not logged. All test fixtures are synthetic; no journal exports or diagnostic response files are included in this PR.

Validation: `python -m unittest discover -v` passes all 36 tests on Python 3.14.6, without network access or LiveJournal credentials. Coverage includes retry boundaries, strict XML validation, private diagnostics, mixed UTF-8/Windows-1251 fields, and legacy text combined with forbidden control characters. The README minimum is corrected to Python 3.12, which the pre-existing f-string syntax already requires.

This PR is independently based on `master`; resumable downloads and account protection are submitted separately.
