### PR TITLE
Resume exports and protect cached data across accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ LiveJournal username and password. It will use that to
 acquire the required session cookies. After this, the
 download process will begin.
 
+To continue an interrupted download, run `python export.py --resume` with the
+same account and the original full date range. Completed monthly XML files are
+validated and reused; both cached and newly downloaded posts are included in the
+result. Comments are downloaded after all posts. Resume also reuses validated
+comment metadata and body batches, continuing the saved snapshot up to its
+recorded maximum comment ID. Without `--resume`, the selected months and comment
+batches are downloaded again.
+
+The first run records the authenticated login name in `posts-xml/.account.json`.
+Every later run, with or without `--resume`, checks this account before reading or
+overwriting saved exports. Passwords and session cookies are not stored. Use
+separate working directories for different journals. Existing exports without
+an account file are assigned to the account used on their first run with this
+version; only resume such a directory with its original account.
+
+Monthly XML, comment batches, and aggregate JSON files are written atomically so
+interruptions cannot leave partially written cache files. Invalid cached XML is
+kept for inspection and stops the export instead of being silently skipped or
+overwritten. Comment pagination stops with an error if the server makes no
+progress. After a failure, use `--resume` to continue from completed files.
+
 ## download_posts.py
 
 This script will download your posts in XML into `posts-xml` 

--- a/authentication.py
+++ b/authentication.py
@@ -1,7 +1,13 @@
 from getpass import getpass
 from sys import exit as sysexit
+import json
+import os
+from pathlib import Path
+import tempfile
 
 import requests
+
+from utilities import ExportError
 
 
 def get_cookie_value(response, name):
@@ -39,12 +45,13 @@ def get_luid_cookie():
 
 
 def get_authenticated_cookies():
+    global cachedUsername
     cookies = {
         'luid': get_luid_cookie()
     }
 
     credentials = {
-        'user': input('Enter LiveJournal Username: '),
+        'user': input('Enter LiveJournal Username: ').strip(),
         'password': getpass('Enter LiveJournal Password: ')
     }
 
@@ -56,11 +63,13 @@ def get_authenticated_cookies():
         sysexit(1)
 
     # prepare two cookies necessary for the authenticated requests
-    print('Login successful!')
-    return {
+    authenticated_cookies = {
         'ljloggedin': get_cookie_value(response, 'ljloggedin'),
         'ljmastersession': get_cookie_value(response, 'ljmastersession')
     }
+    cachedUsername = credentials['user'].casefold()
+    print('Login successful!')
+    return authenticated_cookies
 
 
 headers = {
@@ -68,6 +77,7 @@ headers = {
 }
 
 cachedCookies = None
+cachedUsername = None
 
 
 def authenticated_request_params():
@@ -80,3 +90,40 @@ def authenticated_request_params():
         'headers': headers,
         'cookies': cachedCookies,
     }
+
+
+def bind_export_account(*, resume=False):
+    """Bind new or legacy exports on first use; every later run checks ownership."""
+    authenticated_request_params()
+    if not cachedUsername:
+        raise ExportError('Cannot identify the account for the saved export.')
+    folder = Path('posts-xml')
+    folder.mkdir(exist_ok=True)
+    manifest = folder / '.account.json'
+
+    def check_existing():
+        try:
+            account = json.loads(manifest.read_text(encoding='utf-8'))['username']
+        except (OSError, ValueError, KeyError, TypeError):
+            raise ExportError('Cannot read posts-xml/.account.json; cache left unchanged.') from None
+        if account != cachedUsername:
+            raise ExportError(
+                'The saved export belongs to another account. Use that account '
+                'for this directory, or a separate directory for a different journal.'
+            )
+
+    if manifest.exists():
+        check_existing()
+        return
+    fd, temporary = tempfile.mkstemp(prefix='.account-', dir=folder)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as file:
+            json.dump({'username': cachedUsername}, file)
+            file.flush()
+            os.fsync(file.fileno())
+        try:
+            os.link(temporary, manifest)
+        except FileExistsError:
+            check_existing()
+    finally:
+        os.unlink(temporary)

--- a/download_comments.py
+++ b/download_comments.py
@@ -1,11 +1,15 @@
 #!/usr/bin/python3
 
 import os
-import requests
+import json
+from pathlib import Path
 import xml.etree.ElementTree as ET
 
-from authentication import authenticated_request_params
-from utilities import save_json_file, save_text_file
+from authentication import authenticated_request_params, bind_export_account
+from download_posts import _atomic_write
+import requests
+
+from utilities import ExportError
 
 
 def fetch_xml(params):
@@ -14,9 +18,88 @@ def fetch_xml(params):
         params=params,
         **authenticated_request_params(),
     )
-
     return response.text
 
+
+def _validated_batch(xml, kind, path, *, cached):
+    """Reject error pages and incomplete batches before accepting a cache."""
+    try:
+        root = ET.fromstring(xml)
+        allowed = ({'comments', 'usermaps', 'maxid', 'nextid'}
+                   if kind == 'comment_meta' else {'comments'})
+        if (root.tag != 'livejournal' or (root.text or '').strip()
+                or any(child.tag not in allowed or (child.tail or '').strip()
+                       for child in root)
+                or len(root.findall('comments')) != 1
+                or any(len(root.findall(tag)) > 1 for tag in allowed)):
+            raise ValueError('Unexpected comments export structure')
+        comments = root.find('comments')
+        if ((comments.text or '').strip()
+                or any(child.tag != 'comment' or (child.tail or '').strip()
+                       for child in comments)):
+            raise ValueError('Unexpected comments list')
+        for comment in comments:
+            int(comment.attrib['id'])
+            if kind == 'comment_body':
+                int(comment.attrib['jitemid'])
+                for attribute in ('parentid', 'posterid'):
+                    if attribute in comment.attrib:
+                        int(comment.attrib[attribute])
+                if any(child.tag not in {'date', 'subject', 'body'} for child in comment):
+                    raise ValueError('Unexpected comment body structure')
+        if kind == 'comment_meta':
+            if int(root.findtext('maxid')) < 0:
+                raise ValueError('Invalid maximum comment ID')
+            if root.find('nextid') is not None:
+                int(root.findtext('nextid'))
+            for user in root.iter('usermap'):
+                user.attrib['id']
+                user.attrib['user']
+        return root
+    except (ET.ParseError, ValueError, TypeError, KeyError):
+        detail = ('The existing file was kept. Inspect it or move it aside before retrying.'
+                  if cached else 'No comment batch was saved. Retry with --resume.')
+        raise ExportError(
+            f'{path}: invalid LiveJournal {kind} XML. {detail}'
+        ) from None
+
+
+def _load_batch(kind, start_id, *, resume):
+    path = Path(f'comments-xml/{kind}-{start_id}.xml')
+    cached = resume and path.exists()
+    if cached:
+        try:
+            xml = path.read_text(encoding='utf-8')
+        except (OSError, UnicodeError):
+            raise ExportError(
+                f'{path}: could not read the cached comment batch. '
+                'The existing file was kept; check its encoding and permissions.'
+            ) from None
+        print(f'Using saved {kind} from ID {start_id}...', flush=True)
+    else:
+        print(f'Downloading {kind} from ID {start_id}...', flush=True)
+        xml = fetch_xml({'get': kind, 'startid': start_id})
+    root = _validated_batch(xml, kind, path, cached=cached)
+    if kind == 'comment_body':
+        ids = [int(comment.attrib['id']) for comment in root.find('comments')]
+        if not ids or max(ids) < start_id:
+            detail = ('The existing file was kept; inspect it or move it aside before retrying.'
+                      if cached else 'No comment batch was saved; retry with --resume.')
+            raise ExportError(
+                f'{path}: comment export made no progress before the advertised maximum ID. '
+                f'{detail}'
+            )
+    if kind == 'comment_meta':
+        next_id = root.findtext('nextid')
+        if next_id is not None and int(next_id) <= start_id:
+            detail = ('The existing file was kept; inspect it or move it aside before retrying.'
+                      if cached else 'No comment batch was saved; retry with --resume.')
+            raise ExportError(
+                f'{path}: comment metadata returned a non-advancing next ID. {detail}'
+            )
+    if not cached:
+        _atomic_write(path, xml, replace=not resume)
+    return root
 
 def get_users_map(xml):
     users = {}
@@ -38,14 +121,13 @@ def get_comment_element(name, comment_xml, comment):
         comment[name] = elements[0].text
 
 
-def get_more_comments(start_id, users):
+def get_more_comments(start_id, users, resume=False):
     comments = []
     local_max_id = -1
 
-    xml = fetch_xml({'get': 'comment_body', 'startid': start_id})
-    save_text_file(f'comments-xml/comment_body-{start_id}.xml', xml)
+    root = _load_batch('comment_body', start_id, resume=resume)
 
-    for comment_xml in ET.fromstring(xml).iter('comment'):
+    for comment_xml in root.iter('comment'):
         comment = {
             'jitemid': int(comment_xml.attrib['jitemid']),
             'id': int(comment_xml.attrib['id']),
@@ -69,15 +151,12 @@ def get_more_comments(start_id, users):
     return local_max_id, comments
 
 
-def comment_meta():
+def comment_meta(resume=False):
     start_id = 0
     last_id = -1
 
     while start_id is not None and start_id > last_id:
-        xml = fetch_xml({'get': 'comment_meta', 'startid': start_id})
-        save_text_file(f'comments-xml/comment_meta-{start_id}.xml', xml)
-
-        metadata = ET.fromstring(xml)
+        metadata = _load_batch('comment_meta', start_id, resume=resume)
         yield metadata
 
         last_id = start_id
@@ -85,28 +164,38 @@ def comment_meta():
         start_id = next_id and int(next_id)
 
 
-def download_comments():
+def download_comments(resume=False):
+    bind_export_account(resume=resume)
     os.makedirs('comments-xml', exist_ok=True)
     os.makedirs('comments-json', exist_ok=True)
 
     users = {}
     max_id = None
 
-    for metadata in comment_meta():
+    for metadata in comment_meta(resume=resume):
         users.update(get_users_map(metadata))
 
         if max_id is None:
             max_id = int(metadata.findtext('maxid'))
 
-    save_json_file('comments-json/usermap.json', users)
+    _atomic_write('comments-json/usermap.json',
+                  json.dumps(users, ensure_ascii=False, indent=2), replace=True)
 
     all_comments = []
     start_id = 0
     while max_id is not None and start_id < max_id:
-        start_id, comments = get_more_comments(start_id + 1, users)
+        next_id, comments = get_more_comments(start_id + 1, users, resume=resume)
+        if next_id <= start_id:
+            raise ExportError(
+                f'comments-xml/comment_body-{start_id + 1}.xml: comment export made no '
+                'progress before the advertised maximum ID. Existing files were kept; '
+                'inspect this batch before retrying with --resume.'
+            )
+        start_id = next_id
         all_comments.extend(comments)
 
-    save_json_file('comments-json/all.json', all_comments)
+    _atomic_write('comments-json/all.json',
+                  json.dumps(all_comments, ensure_ascii=False, indent=2), replace=True)
 
     return all_comments
 

--- a/download_posts.py
+++ b/download_posts.py
@@ -1,14 +1,18 @@
 #!/usr/bin/python3
 
 import os
-import requests
+import json
+import tempfile
+from pathlib import Path
 from sys import exit as sysexit
 import xml.etree.ElementTree as ET
-from datetime import datetime, timedelta
+from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
-from authentication import authenticated_request_params
-from utilities import save_json_file, save_text_file
+from authentication import authenticated_request_params, bind_export_account
+import requests
+
+from utilities import ExportError
 
 DATE_FORMAT = '%Y-%m'
 
@@ -80,11 +84,61 @@ def xml_to_json(xml):
     }
 
 
-def download_posts():
+def _month_entries(xml, path, *, cached):
+    """Accept only the monthly export envelope, never an error or login page."""
+    try:
+        root = ET.fromstring(xml)
+        if (root.tag != 'livejournal' or (root.text or '').strip()
+                or any(child.tag != 'entry' or (child.tail or '').strip() for child in root)):
+            raise ValueError('Unexpected export structure')
+        return list(root)
+    except (ET.ParseError, ValueError):
+        if cached:
+            detail = ('The existing file was kept. Inspect it or move it aside '
+                      'before retrying this month.')
+        else:
+            detail = 'No month file was saved. Retry the export to resume.'
+        raise ExportError(
+            f'{path}: invalid monthly LiveJournal XML. {detail}'
+        ) from None
+
+
+def _atomic_write(path, content, *, replace):
+    """Publish complete files only; a new monthly cache must never clobber a file."""
+    path = Path(path)
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+                mode='w', encoding='utf-8', dir=path.parent,
+                prefix=f'.{path.name}.', suffix='.tmp', delete=False) as output:
+            temporary = Path(output.name)
+            output.write(content)
+            output.flush()
+            os.fsync(output.fileno())
+        if replace:
+            os.replace(temporary, path)
+        else:
+            # link() atomically creates the target and fails if it already exists.
+            os.link(temporary, path)
+    except OSError:
+        raise ExportError(
+            f'{path}: could not save the completed export. '
+            'Existing files were kept; check available space and file permissions.'
+        ) from None
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def download_posts(resume=False):
+    start_month, end_month = get_months()
+    if end_month < start_month:
+        raise ExportError('End month must not be earlier than start month.')
+
+    # Check ownership before reading caches or overwriting any previous export.
+    bind_export_account(resume=resume)
     os.makedirs('posts-xml', exist_ok=True)
     os.makedirs('posts-json', exist_ok=True)
-
-    start_month, end_month = get_months()
 
     xml_posts = []
     month_cursor = start_month
@@ -93,15 +147,30 @@ def download_posts():
         year = month_cursor.year
         month = month_cursor.month
 
-        xml = fetch_month_posts(year, month)
-        xml_posts.extend(list(ET.fromstring(xml).iter('entry')))
-
-        save_text_file(f'posts-xml/{year}-{month:02d}.xml', xml)
+        path = Path(f'posts-xml/{year}-{month:02d}.xml')
+        if resume and path.exists():
+            try:
+                xml = path.read_text(encoding='utf-8')
+            except (OSError, UnicodeError):
+                raise ExportError(
+                    f'{path}: could not read the cached month. '
+                    'The existing file was kept; check its encoding and permissions.'
+                ) from None
+            entries = _month_entries(xml, path, cached=True)
+            print(f'Using saved posts for {year}-{month:02d} ({len(entries)} entries)...',
+                  flush=True)
+        else:
+            print(f'Downloading posts for {year}-{month:02d}...', flush=True)
+            xml = fetch_month_posts(year, month)
+            entries = _month_entries(xml, path, cached=False)
+            _atomic_write(path, xml, replace=not resume)
+        xml_posts.extend(entries)
 
         month_cursor = month_cursor + relativedelta(months=1)
 
     json_posts = list(map(xml_to_json, xml_posts))
-    save_json_file('posts-json/all.json', json_posts)
+    _atomic_write('posts-json/all.json',
+                  json.dumps(json_posts, ensure_ascii=False, indent=2), replace=True)
 
     return json_posts
 

--- a/export.py
+++ b/export.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import os
+import argparse
 import json
 import re
 import html2text
@@ -11,7 +12,7 @@ from operator import itemgetter
 
 from download_posts import download_posts
 from download_comments import download_comments
-from utilities import save_json_file, save_text_file
+from utilities import ExportError, save_json_file, save_text_file
 
 COMMENTS_HEADER = 'Комментарии'
 
@@ -200,13 +201,24 @@ def combine(all_posts, all_comments):
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Export LiveJournal posts and comments.')
+    parser.add_argument('--resume', action='store_true',
+                        help='Reuse saved post months and comment batches for the same account and date range.')
+    args = parser.parse_args()
     if True:
         print('Downloading posts and comments…')
         print(
             'When complete, you will find post-… and comment-… folders in the current location\ncontaining the differently formated versions of your content.')
 
-        all_posts = download_posts()
-        all_comments = download_comments()
+        try:
+            all_posts = download_posts(resume=args.resume)
+            all_comments = download_comments(resume=args.resume)
+        except ExportError as error:
+            raise SystemExit(
+                f'Export stopped: {error}\n'
+                'Downloaded files are kept. Rerun with --resume using the same '
+                'account and date range to skip saved post months and comment batches.'
+            ) from None
 
     else:
         print('Processing previously downloaded posts and comments…')

--- a/test_account_binding.py
+++ b/test_account_binding.py
@@ -1,0 +1,138 @@
+import contextlib
+from datetime import datetime
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import authentication
+import download_comments
+import download_posts
+from utilities import ExportError
+
+
+class AccountBindingTests(unittest.TestCase):
+    def setUp(self):
+        folder = self.enterContext(tempfile.TemporaryDirectory())
+        self.enterContext(contextlib.chdir(folder))
+        self.enterContext(patch.object(authentication, 'cachedUsername', 'fixture-user'))
+        self.enterContext(patch.object(authentication, 'authenticated_request_params',
+                                      return_value={'cookies': {'session': 'private-test-cookie'}}))
+
+    def test_binding_stores_only_username_and_accepts_same_account(self):
+        authentication.bind_export_account(resume=True)
+        manifest = Path('posts-xml/.account.json')
+        self.assertEqual(json.loads(manifest.read_text()), {'username': 'fixture-user'})
+        self.assertEqual(manifest.stat().st_mode & 0o777, 0o600)
+        authentication.bind_export_account(resume=True)
+
+    def test_other_account_stops_and_keeps_manifest(self):
+        authentication.bind_export_account(resume=True)
+        manifest = Path('posts-xml/.account.json')
+        original = manifest.read_bytes()
+        with patch.object(authentication, 'cachedUsername', 'another-user'):
+            with self.assertRaises(ExportError):
+                authentication.bind_export_account(resume=True)
+        self.assertEqual(manifest.read_bytes(), original)
+
+    def test_invalid_manifest_stops_without_overwriting_it(self):
+        Path('posts-xml').mkdir()
+        manifest = Path('posts-xml/.account.json')
+        manifest.write_text('invalid-json')
+        with self.assertRaises(ExportError):
+            authentication.bind_export_account(resume=True)
+        self.assertEqual(manifest.read_text(), 'invalid-json')
+
+    def test_first_ordinary_run_adopts_legacy_cache_without_changing_it(self):
+        Path('posts-xml').mkdir()
+        legacy = Path('posts-xml/2009-03.xml')
+        legacy.write_bytes(b'<livejournal/>')
+
+        authentication.bind_export_account()
+
+        self.assertEqual(legacy.read_bytes(), b'<livejournal/>')
+        self.assertEqual(json.loads(Path('posts-xml/.account.json').read_text()),
+                         {'username': 'fixture-user'})
+
+    def _existing_export(self):
+        authentication.bind_export_account()
+        files = {
+            'posts-xml/2009-03.xml': '<livejournal/>',
+            'posts-json/all.json': '["previous posts"]',
+            'comments-xml/comment_meta-0.xml': '<livejournal/>',
+            'comments-xml/comment_body-1.xml': '<livejournal/>',
+            'comments-json/usermap.json': '{"10": "previous-reader"}',
+            'comments-json/all.json': '["previous comments"]',
+        }
+        for name, content in files.items():
+            path = Path(name)
+            path.parent.mkdir(exist_ok=True)
+            path.write_text(content, encoding='utf-8')
+        return {path: path.read_bytes() for path in Path('.').rglob('*') if path.is_file()}
+
+    def _allow_manifest_read_only(self):
+        read_text = Path.read_text
+
+        def checked_read(path, *args, **kwargs):
+            self.assertEqual(path, Path('posts-xml/.account.json'),
+                             'An export cache was read before account validation')
+            return read_text(path, *args, **kwargs)
+
+        return patch.object(Path, 'read_text', checked_read)
+
+    def test_account_mismatch_blocks_post_refresh_and_resume_without_cache_changes(self):
+        original = self._existing_export()
+        for resume in (False, True):
+            with self.subTest(resume=resume), \
+                    patch.object(authentication, 'cachedUsername', 'another-user'), \
+                    patch.object(download_posts, 'get_months', return_value=(
+                        datetime(2009, 3, 1), datetime(2009, 3, 1))), \
+                    patch.object(download_posts, 'fetch_month_posts') as fetch, \
+                    patch.object(download_posts, '_atomic_write') as save, \
+                    patch.object(download_posts.os, 'makedirs') as mkdir, \
+                    self._allow_manifest_read_only():
+                with self.assertRaisesRegex(ExportError, 'another account'):
+                    download_posts.download_posts(resume=resume)
+                fetch.assert_not_called()
+                save.assert_not_called()
+                mkdir.assert_not_called()
+            self.assertEqual(
+                {path: path.read_bytes() for path in Path('.').rglob('*') if path.is_file()},
+                original)
+
+    def test_account_mismatch_blocks_standalone_comment_refresh_and_resume(self):
+        original = self._existing_export()
+        for resume in (False, True):
+            with self.subTest(resume=resume), \
+                    patch.object(authentication, 'cachedUsername', 'another-user'), \
+                    patch.object(download_comments, 'fetch_xml') as fetch, \
+                    patch.object(download_comments, '_atomic_write') as save, \
+                    patch.object(download_comments.os, 'makedirs') as mkdir, \
+                    self._allow_manifest_read_only():
+                with self.assertRaisesRegex(ExportError, 'another account'):
+                    download_comments.download_comments(resume=resume)
+                fetch.assert_not_called()
+                save.assert_not_called()
+                mkdir.assert_not_called()
+            self.assertEqual(
+                {path: path.read_bytes() for path in Path('.').rglob('*') if path.is_file()},
+                original)
+
+
+class AuthenticationReuseTests(unittest.TestCase):
+    def test_repeated_account_checks_reuse_authenticated_session(self):
+        with tempfile.TemporaryDirectory() as folder, contextlib.chdir(folder), \
+                patch.object(authentication, 'cachedUsername', 'fixture-user'), \
+                patch.object(authentication, 'cachedCookies', None), \
+                patch.object(authentication, 'get_authenticated_cookies',
+                             return_value={'session': 'private-test-cookie'}) as login:
+            authentication.bind_export_account()
+            authentication.bind_export_account(resume=True)
+            authentication.bind_export_account()
+
+            login.assert_called_once_with()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_comment_resume.py
+++ b/test_comment_resume.py
@@ -1,0 +1,222 @@
+"""Offline checks for continuing comment batches after an interrupted export."""
+
+import contextlib
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import download_comments
+from utilities import ExportError
+
+
+def metadata_xml(max_id, next_id=None, user_id=10):
+    next_tag = '' if next_id is None else f'<nextid>{next_id}</nextid>'
+    return (f'<livejournal><maxid>{max_id}</maxid>{next_tag}'
+            f'<usermaps><usermap id="{user_id}" user="reader-{user_id}"/></usermaps>'
+            '<comments/></livejournal>')
+
+
+def body_xml(*ids):
+    comments = ''.join(
+        f'<comment id="{comment_id}" jitemid="7" posterid="10">'
+        f'<body>Comment {comment_id}</body></comment>' for comment_id in ids)
+    return f'<livejournal><comments>{comments}</comments></livejournal>'
+
+
+class CommentResumeTests(unittest.TestCase):
+    def setUp(self):
+        folder = self.enterContext(tempfile.TemporaryDirectory())
+        self.enterContext(contextlib.chdir(folder))
+        self.enterContext(contextlib.redirect_stdout(io.StringIO()))
+        Path('comments-xml').mkdir()
+        Path('comments-json').mkdir()
+        self.fetch = self.enterContext(patch.object(download_comments, 'fetch_xml'))
+        self.bind = self.enterContext(patch.object(download_comments, 'bind_export_account'))
+
+    def cache(self, kind, start_id, xml):
+        path = Path(f'comments-xml/{kind}-{start_id}.xml')
+        path.write_text(xml, encoding='utf-8')
+        return path
+
+    def assert_no_temporary_files(self):
+        self.assertEqual(list(Path('.').rglob('*.tmp')), [])
+
+    def test_all_cached_pages_rebuild_aggregate_without_network(self):
+        paths = [
+            self.cache('comment_meta', 0, metadata_xml(3, 2)),
+            self.cache('comment_meta', 2, metadata_xml(3, user_id=11)),
+            self.cache('comment_body', 1, body_xml(1, 2)),
+            self.cache('comment_body', 3, body_xml(3)),
+        ]
+        originals = {path: path.read_bytes() for path in paths}
+
+        comments = download_comments.download_comments(resume=True)
+
+        self.bind.assert_called_once_with(resume=True)
+        self.fetch.assert_not_called()
+        self.assertEqual([comment['id'] for comment in comments], [1, 2, 3])
+        self.assertEqual(comments[0]['author'], 'reader-10')
+        self.assertEqual(json.loads(Path('comments-json/all.json').read_text()), comments)
+        self.assertEqual(json.loads(Path('comments-json/usermap.json').read_text()),
+                         {'10': 'reader-10', '11': 'reader-11'})
+        self.assertEqual({path: path.read_bytes() for path in paths}, originals)
+        self.assert_no_temporary_files()
+
+    def test_only_missing_body_batch_is_downloaded(self):
+        self.cache('comment_meta', 0, metadata_xml(3))
+        first = self.cache('comment_body', 1, body_xml(1, 2))
+        original = first.read_bytes()
+        self.fetch.return_value = body_xml(3)
+
+        comments = download_comments.download_comments(resume=True)
+
+        self.fetch.assert_called_once_with({'get': 'comment_body', 'startid': 3})
+        self.assertEqual([comment['id'] for comment in comments], [1, 2, 3])
+        self.assertEqual(first.read_bytes(), original)
+        self.assertEqual(Path('comments-xml/comment_body-3.xml').read_text(), body_xml(3))
+        self.assert_no_temporary_files()
+
+    def test_invalid_metadata_cache_is_preserved_without_network(self):
+        invalid_samples = (
+            '<livejournal>',
+            '<html><body>private sample</body></html>',
+            '<livejournal><error>private sample</error></livejournal>',
+            '<livejournal><comments/></livejournal>',
+            '<livejournal><maxid>not a number</maxid><comments/></livejournal>',
+            '<livejournal><maxid>3</maxid><comments/><comments/></livejournal>',
+        )
+        for xml in invalid_samples:
+            with self.subTest(xml=xml):
+                path = self.cache('comment_meta', 0, xml)
+                aggregate = Path('comments-json/all.json')
+                aggregate.write_text('previous aggregate')
+
+                with self.assertRaises(ExportError) as caught:
+                    download_comments.download_comments(resume=True)
+
+                self.fetch.assert_not_called()
+                self.assertEqual(path.read_text(), xml)
+                self.assertEqual(aggregate.read_text(), 'previous aggregate')
+                self.assertIn('existing file was kept', str(caught.exception))
+                self.assertNotIn('private sample', str(caught.exception))
+                self.assert_no_temporary_files()
+
+    def test_invalid_body_cache_is_preserved_without_network(self):
+        self.cache('comment_meta', 0, metadata_xml(3))
+        invalid_samples = (
+            '<livejournal><maxid>3</maxid><comments/></livejournal>',
+            '<livejournal><comments><error>private sample</error></comments></livejournal>',
+            '<livejournal><comments><comment id="1"/></comments></livejournal>',
+            '<livejournal><comments><comment id="1" jitemid="7" posterid="bad"/></comments></livejournal>',
+        )
+        for xml in invalid_samples:
+            with self.subTest(xml=xml):
+                path = self.cache('comment_body', 1, xml)
+                aggregate = Path('comments-json/all.json')
+                aggregate.write_text('previous aggregate')
+
+                with self.assertRaises(ExportError) as caught:
+                    download_comments.download_comments(resume=True)
+
+                self.fetch.assert_not_called()
+                self.assertEqual(path.read_text(), xml)
+                self.assertEqual(aggregate.read_text(), 'previous aggregate')
+                self.assertNotIn('private sample', str(caught.exception))
+
+    def test_unreadable_encoding_cache_is_preserved(self):
+        self.cache('comment_meta', 0, metadata_xml(3))
+        path = Path('comments-xml/comment_body-1.xml')
+        path.write_bytes(b'\xff')
+
+        with self.assertRaisesRegex(ExportError, 'encoding and permissions'):
+            download_comments.download_comments(resume=True)
+
+        self.fetch.assert_not_called()
+        self.assertEqual(path.read_bytes(), b'\xff')
+
+    def test_empty_new_batch_stops_without_saving_or_overwriting_aggregate(self):
+        self.cache('comment_meta', 0, metadata_xml(3))
+        self.fetch.return_value = body_xml()
+        aggregate = Path('comments-json/all.json')
+        aggregate.write_text('previous aggregate')
+
+        with self.assertRaisesRegex(ExportError, 'made no progress') as caught:
+            download_comments.download_comments(resume=True)
+
+        self.fetch.assert_called_once_with({'get': 'comment_body', 'startid': 1})
+        self.assertIn('--resume', str(caught.exception))
+        self.assertFalse(Path('comments-xml/comment_body-1.xml').exists())
+        self.assertEqual(aggregate.read_text(), 'previous aggregate')
+        self.assert_no_temporary_files()
+
+    def test_nonadvancing_cached_batch_stops_and_preserves_file(self):
+        self.cache('comment_meta', 0, metadata_xml(3))
+        self.cache('comment_body', 1, body_xml(1, 2))
+        path = self.cache('comment_body', 3, body_xml(1, 2))
+
+        with self.assertRaisesRegex(ExportError, 'made no progress') as caught:
+            download_comments.download_comments(resume=True)
+
+        self.fetch.assert_not_called()
+        self.assertIn(str(path), str(caught.exception))
+        self.assertIn('existing file was kept', str(caught.exception))
+        self.assertEqual(path.read_text(), body_xml(1, 2))
+        self.assertFalse(Path('comments-json/all.json').exists())
+
+    def test_nonadvancing_metadata_stops_before_body_download(self):
+        path = self.cache('comment_meta', 0, metadata_xml(3, 0))
+
+        with self.assertRaisesRegex(ExportError, 'non-advancing next ID'):
+            download_comments.download_comments(resume=True)
+
+        self.fetch.assert_not_called()
+        self.assertEqual(path.read_text(), metadata_xml(3, 0))
+        self.assertFalse(Path('comments-json/all.json').exists())
+
+    def test_zero_comments_creates_valid_empty_aggregate(self):
+        self.cache('comment_meta', 0, metadata_xml(0))
+
+        self.assertEqual(download_comments.download_comments(resume=True), [])
+
+        self.fetch.assert_not_called()
+        self.assertEqual(json.loads(Path('comments-json/all.json').read_text()), [])
+
+    def test_default_mode_downloads_batches_again(self):
+        self.cache('comment_meta', 0, metadata_xml(3))
+        self.cache('comment_body', 1, body_xml(1, 2, 3))
+        self.fetch.side_effect = [metadata_xml(1), body_xml(1)]
+
+        comments = download_comments.download_comments()
+
+        self.bind.assert_called_once_with(resume=False)
+        self.assertEqual(self.fetch.call_count, 2)
+        self.assertEqual([comment['id'] for comment in comments], [1])
+        self.assertEqual(Path('comments-xml/comment_body-1.xml').read_text(), body_xml(1))
+        self.assert_no_temporary_files()
+
+    def test_new_batch_is_kept_if_aggregate_publication_fails(self):
+        self.cache('comment_meta', 0, metadata_xml(1))
+        self.fetch.return_value = body_xml(1)
+        aggregate = Path('comments-json/all.json')
+        aggregate.write_text('previous aggregate')
+        real_write = download_comments._atomic_write
+
+        def fail_aggregate(path, content, *, replace):
+            if str(path) == 'comments-json/all.json':
+                raise ExportError('Could not publish aggregate')
+            return real_write(path, content, replace=replace)
+
+        with patch.object(download_comments, '_atomic_write', side_effect=fail_aggregate):
+            with self.assertRaisesRegex(ExportError, 'publish aggregate'):
+                download_comments.download_comments(resume=True)
+
+        self.assertEqual(Path('comments-xml/comment_body-1.xml').read_text(), body_xml(1))
+        self.assertEqual(aggregate.read_text(), 'previous aggregate')
+        self.assert_no_temporary_files()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_resume.py
+++ b/test_resume.py
@@ -1,0 +1,179 @@
+"""Offline checks for retaining completed months across interrupted exports."""
+
+import contextlib
+from datetime import datetime
+import io
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import download_posts
+from utilities import ExportError
+
+
+def month_xml(item_id):
+    return (
+        '<livejournal><entry>'
+        f'<itemid>{item_id}</itemid><logtime>2009-03-01 12:00:00</logtime>'
+        '<subject>Sample post</subject><event>Sample body</event>'
+        '</entry></livejournal>'
+    )
+
+
+class ResumeTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = self.enterContext(tempfile.TemporaryDirectory())
+        self.previous_cwd = Path.cwd()
+        os.chdir(self.temporary)
+        self.addCleanup(os.chdir, self.previous_cwd)
+        Path('posts-xml').mkdir()
+        Path('posts-json').mkdir()
+        self.output = io.StringIO()
+        self.enterContext(contextlib.redirect_stdout(self.output))
+        self.months = self.enterContext(patch.object(
+            download_posts, 'get_months', return_value=(
+                datetime(2009, 3, 1), datetime(2009, 4, 1))))
+        self.fetch = self.enterContext(patch.object(download_posts, 'fetch_month_posts'))
+        self.bind = self.enterContext(patch.object(download_posts, 'bind_export_account'))
+
+    def cache(self, month, xml):
+        path = Path(f'posts-xml/{month}.xml')
+        path.write_text(xml, encoding='utf-8')
+        return path
+
+    def assert_no_temporary_files(self):
+        self.assertEqual(list(Path('.').rglob('*.tmp')), [])
+
+    def test_resume_uses_completed_month_and_downloads_only_missing_month(self):
+        path = self.cache('2009-03', month_xml(1))
+        original = path.read_bytes()
+        self.fetch.return_value = month_xml(2)
+
+        posts = download_posts.download_posts(resume=True)
+
+        self.bind.assert_called_once_with(resume=True)
+        self.fetch.assert_called_once_with(2009, 4)
+        self.assertEqual([post['id'] for post in posts], [1, 2])
+        self.assertEqual(path.read_bytes(), original)
+        self.assertEqual(json.loads(Path('posts-json/all.json').read_text()), posts)
+        self.assertEqual(Path('posts-xml/2009-04.xml').read_text(), month_xml(2))
+        self.assert_no_temporary_files()
+
+    def test_all_cached_months_are_included_without_network_calls(self):
+        self.cache('2009-03', month_xml(1))
+        self.cache('2009-04', month_xml(2))
+
+        posts = download_posts.download_posts(resume=True)
+
+        self.fetch.assert_not_called()
+        self.assertEqual([post['id'] for post in posts], [1, 2])
+
+    def test_empty_month_is_a_valid_cache(self):
+        self.cache('2009-03', '<livejournal/>')
+        self.cache('2009-04', month_xml(2))
+
+        posts = download_posts.download_posts(resume=True)
+
+        self.fetch.assert_not_called()
+        self.assertEqual([post['id'] for post in posts], [2])
+
+    def test_invalid_cache_stops_without_replacing_it_or_aggregate(self):
+        invalid_samples = (
+            '<livejournal>',
+            '<html><body>private sample</body></html>',
+            '<livejournal><error>private sample</error></livejournal>',
+            '<livejournal>private sample</livejournal>',
+            '<response><entry/></response>',
+        )
+        for xml in invalid_samples:
+            with self.subTest(xml=xml):
+                path = self.cache('2009-03', xml)
+                aggregate = Path('posts-json/all.json')
+                aggregate.write_text('previous complete aggregate')
+
+                with self.assertRaises(ExportError) as caught:
+                    download_posts.download_posts(resume=True)
+
+                self.fetch.assert_not_called()
+                self.assertEqual(path.read_text(), xml)
+                self.assertEqual(aggregate.read_text(), 'previous complete aggregate')
+                self.assertIn('existing file was kept', str(caught.exception))
+                self.assertNotIn('private sample', str(caught.exception))
+                self.assert_no_temporary_files()
+
+    def test_account_mismatch_stops_before_reading_or_downloading_months(self):
+        path = self.cache('2009-03', month_xml(1))
+        original = path.read_bytes()
+        self.bind.side_effect = ExportError('Different account')
+
+        with self.assertRaisesRegex(ExportError, 'Different account'):
+            download_posts.download_posts(resume=True)
+
+        self.fetch.assert_not_called()
+        self.assertEqual(path.read_bytes(), original)
+        self.assertFalse(Path('posts-json/all.json').exists())
+
+    def test_invalid_new_month_is_never_saved(self):
+        self.fetch.return_value = '<livejournal><error>private sample</error></livejournal>'
+
+        with self.assertRaises(ExportError):
+            download_posts.download_posts(resume=True)
+
+        self.assertFalse(Path('posts-xml/2009-03.xml').exists())
+        self.assertFalse(Path('posts-json/all.json').exists())
+        self.assert_no_temporary_files()
+
+    def test_interruption_during_publish_retains_previous_completed_month(self):
+        original = self.cache('2009-03', month_xml(1)).read_bytes()
+        self.fetch.return_value = month_xml(2)
+        with patch.object(download_posts.os, 'link', side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                download_posts.download_posts(resume=True)
+
+        self.assertEqual(Path('posts-xml/2009-03.xml').read_bytes(), original)
+        self.assertFalse(Path('posts-xml/2009-04.xml').exists())
+        self.assert_no_temporary_files()
+
+    def test_aggregate_publication_failure_keeps_previous_aggregate_and_new_month(self):
+        self.cache('2009-03', month_xml(1))
+        self.fetch.return_value = month_xml(2)
+        aggregate = Path('posts-json/all.json')
+        aggregate.write_text('previous complete aggregate')
+        with patch.object(download_posts.os, 'replace', side_effect=OSError('disk full')):
+            with self.assertRaises(ExportError):
+                download_posts.download_posts(resume=True)
+
+        self.assertEqual(aggregate.read_text(), 'previous complete aggregate')
+        self.assertEqual(Path('posts-xml/2009-04.xml').read_text(), month_xml(2))
+        self.assert_no_temporary_files()
+
+    def test_new_cache_publication_never_clobbers_a_concurrent_file(self):
+        path = Path('posts-xml/2009-04.xml')
+        path.write_text('written by another export')
+
+        with self.assertRaises(ExportError):
+            download_posts._atomic_write(path, month_xml(2), replace=False)
+
+        self.assertEqual(path.read_text(), 'written by another export')
+        self.assert_no_temporary_files()
+
+    def test_default_mode_downloads_range_again(self):
+        self.cache('2009-03', month_xml(1))
+        self.cache('2009-04', month_xml(2))
+        self.fetch.side_effect = [month_xml(3), month_xml(4)]
+
+        posts = download_posts.download_posts()
+
+        self.bind.assert_called_once_with(resume=False)
+        self.assertEqual([post['id'] for post in posts], [3, 4])
+        self.assertEqual(self.fetch.call_count, 2)
+        self.assertEqual(Path('posts-xml/2009-03.xml').read_text(), month_xml(3))
+        self.assertEqual(Path('posts-xml/2009-04.xml').read_text(), month_xml(4))
+        self.assert_no_temporary_files()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utilities.py
+++ b/utilities.py
@@ -1,6 +1,10 @@
 import json
 
 
+class ExportError(Exception):
+    """An export cannot continue safely without user intervention."""
+
+
 def save_text_file(name, text):
     with open(name, 'w', encoding='utf-8') as file:
         file.write(text)


### PR DESCRIPTION
An interrupted export currently requires downloading completed months and comment batches again, and reusing a working directory for another account can mix or overwrite saved exports. This change adds `--resume` and checks the authenticated account before reading or writing the export cache, in both normal and resume mode, including standalone comment downloads.

Resume validates and reuses completed monthly XML files, includes cached posts in the final JSON, and continues comment downloads from validated metadata/body batches up to the saved snapshot's maximum comment ID. Invalid cache files are preserved and reported, and pagination fails explicitly when the server makes no progress. XML and aggregate JSON outputs are written atomically so an interrupted write cannot leave a partial cache file.

The account marker stores only the authenticated login name in `posts-xml/.account.json`, never passwords or session cookies. A later run under another account stops before accessing saved exports. Existing unlabelled caches are assigned to the account used on the first run of this version; the README documents that such directories must be resumed with their original account.

Validation: `python -m unittest discover -v` passes all 28 tests on Python 3.14.6, without network access or LiveJournal credentials. Tests cover reused months, comment continuation and corrupt caches, atomic writes, pagination progress, and account mismatch rejection before cache access in normal, resume, and standalone comment modes. `python export.py --help` and `git diff --check` also pass. All fixtures are synthetic.

This PR is independently based on `master`; export request retries and historical XML encoding handling are in #29. Neither PR includes the other's commits.
